### PR TITLE
Fixing minor Dockerfile style issues & command reorder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM debian:latest
 
-add stamus-packages.list /etc/apt/sources.list.d/
-run apt-get update
-run DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg
-run wget -O - -q http://packages.stamus-networks.com/packages.stamus-networks.com.gpg.key | apt-key add -
-run apt-get update
-run DEBIAN_FRONTEND=noninteractive apt-get install -y suricata supervisor python-pyinotify psmisc ethtool
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg
+COPY stamus-packages.list /etc/apt/sources.list.d/
+RUN wget -O - -q http://packages.stamus-networks.com/packages.stamus-networks.com.gpg.key | apt-key add -
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y suricata supervisor python-pyinotify psmisc ethtool
 COPY supervisor.d/* /etc/supervisor/conf.d/
 COPY suri_reloader /usr/local/sbin/suri_reloader
-run chmod +x /usr/local/sbin/suri_reloader
-run mkdir /var/run/suricata/
+RUN chmod +x /usr/local/sbin/suri_reloader
+RUN mkdir /var/run/suricata/
 
 CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]


### PR DESCRIPTION
Current order causes an error during first update due to an unsigned source (because the key isn't introduced until a few lines later).
Changes the ADD command to the preferred COPY command. ADD should not be used anywhere COPY would suffice.